### PR TITLE
docs: GitHubリポジトリのリンクとバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Code Playground
 
+[![GitHub](https://img.shields.io/badge/GitHub-Repository-blue)](https://github.com/Hondy000/claude-code-playground)
+
 Claude Codeの機能をテストするための開発環境です。複数のミニアプリケーションを管理するプロジェクト構造になっています。
 
 ## ディレクトリ構造
@@ -51,7 +53,7 @@ python3 tests/calculator/test_calculator.py -v
 ## セットアップ
 ```bash
 # リポジトリをクローン
-git clone <repository-url>
+git clone https://github.com/Hondy000/claude-code-playground.git
 cd claude-code-playground
 
 # 必要に応じて仮想環境を作成（推奨）


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include a GitHub badge linking to the repository.
  - Replaced placeholder text in setup instructions with the actual repository URL for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->