### PR TITLE
fix: GitHub Actionsの権限エラーを修正

### DIFF
--- a/.github/workflows/coderabbit.yml
+++ b/.github/workflows/coderabbit.yml
@@ -6,6 +6,11 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 # CodeRabbitの設定
 # パブリックリポジトリなので無料で利用可能
 # セットアップ手順:


### PR DESCRIPTION
- coderabbit.ymlにpermissionsセクションを追加
- pull-requestsとissuesへの書き込み権限を追加
- これにより'Resource not accessible by integration'エラーが解決される