### PR TITLE
fix: github-scriptにGITHUB_TOKENを追加

### DIFF
--- a/.github/workflows/coderabbit.yml
+++ b/.github/workflows/coderabbit.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Comment setup instructions
       uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const body = `## 🐰 CodeRabbit AI レビューについて
           


### PR DESCRIPTION
actions/github-script@v7でgithub-tokenパラメータが必要
secrets.GITHUB_TOKENを使用してアクセストークンを提供

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to improve authentication when posting comments on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->